### PR TITLE
Add support for interactive Google Maps using the Google Maps API

### DIFF
--- a/mezzanine_agenda/defaults.py
+++ b/mezzanine_agenda/defaults.py
@@ -93,3 +93,11 @@ register_setting(
     editable=True,
     default=True,
 )
+
+register_setting(
+    name="EVENT_GOOGLE_MAPS_API_KEY",
+    description="If set, interactive google maps embed will be used instead of static images",
+    editable=True,
+    default=True,
+)
+

--- a/mezzanine_agenda/templates/agenda/event_detail.html
+++ b/mezzanine_agenda/templates/agenda/event_detail.html
@@ -88,7 +88,11 @@
 	    Get Directions
 	</a>
     </p>
-    {% google_static_map event 621 250 10 %}
+    {% if settings.EVENT_GOOGLE_MAPS_API_KEY %}
+        {% google_interactive_map event 621 250 10 %}
+    {% else %}
+        {% google_static_map event 621 250 10 %}
+    {% endif %}
     </div>
 </div>
 {% endeditable %}

--- a/mezzanine_agenda/templatetags/event_tags.py
+++ b/mezzanine_agenda/templatetags/event_tags.py
@@ -211,6 +211,17 @@ def google_static_map(event, width, height, zoom):
     return mark_safe("<img src='http://maps.googleapis.com/maps/api/staticmap?size={width}x{height}&scale={scale}&format=png&markers={marker}&sensor=false&zoom={zoom}' width='{width}' height='{height}' />".format(**locals()))
 
 
+@register.simple_tag
+def google_interactive_map(event, width, height, zoom, map_type='roadmap'):
+    """
+    Generates an interactive google map for the event location.
+    """
+    location = quote(event.location.mappable_location)
+    api_key = settings.EVENT_GOOGLE_MAPS_API_KEY
+    center = marker = quote('{:.6},{:.6}'.format(event.location.lat, event.location.lon))
+    return mark_safe('<iframe width="{width}" height="{height}" frameborder="0" style="border:0" src="https://www.google.com/maps/embed/v1/place?q={location}&zoom={zoom}&center={center}&maptype={map_type}&key={api_key}" allowfullscreen></iframe>'.format(**locals()))
+
+
 @register.simple_tag(takes_context=True)
 def icalendar_url(context):
     """


### PR DESCRIPTION
I've added support for Google Maps interactive embeds to improve the static images. This is optional (The static images still work as normal) and thus shouldn't affect existing installations, it's only activated if you set settings.EVENT_GOOGLE_MAPS_API_KEY