### PR TITLE
add initial migration

### DIFF
--- a/mezzanine_agenda/migrations/0001_initial.py
+++ b/mezzanine_agenda/migrations/0001_initial.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import mezzanine.core.fields
+import mezzanine.utils.models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sites', '0001_initial'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Event',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('comments_count', models.IntegerField(default=0, editable=False)),
+                ('keywords_string', models.CharField(max_length=500, editable=False, blank=True)),
+                ('rating_count', models.IntegerField(default=0, editable=False)),
+                ('rating_sum', models.IntegerField(default=0, editable=False)),
+                ('rating_average', models.FloatField(default=0, editable=False)),
+                ('title', models.CharField(max_length=500, verbose_name='Title')),
+                ('slug', models.CharField(help_text='Leave blank to have the URL auto-generated from the title.', max_length=2000, null=True, verbose_name='URL', blank=True)),
+                ('_meta_title', models.CharField(help_text='Optional title to be used in the HTML title tag. If left blank, the main title field will be used.', max_length=500, null=True, verbose_name='Title', blank=True)),
+                ('description', models.TextField(verbose_name='Description', blank=True)),
+                ('gen_description', models.BooleanField(default=True, help_text='If checked, the description will be automatically generated from content. Uncheck if you want to manually set a custom description.', verbose_name='Generate description')),
+                ('created', models.DateTimeField(null=True, editable=False)),
+                ('updated', models.DateTimeField(null=True, editable=False)),
+                ('status', models.IntegerField(default=2, help_text='With Draft chosen, will only be shown for admin users on the site.', verbose_name='Status', choices=[(1, 'Draft'), (2, 'Published')])),
+                ('publish_date', models.DateTimeField(help_text="With Published chosen, won't be shown until this time", null=True, verbose_name='Published from', db_index=True, blank=True)),
+                ('expiry_date', models.DateTimeField(help_text="With Published chosen, won't be shown after this time", null=True, verbose_name='Expires on', blank=True)),
+                ('short_url', models.URLField(null=True, blank=True)),
+                ('in_sitemap', models.BooleanField(default=True, verbose_name='Show in sitemap')),
+                ('content', mezzanine.core.fields.RichTextField(verbose_name='Content')),
+                ('start', models.DateTimeField(verbose_name='Start')),
+                ('end', models.DateTimeField(null=True, verbose_name='End', blank=True)),
+                ('facebook_event', models.BigIntegerField(null=True, verbose_name='Facebook', blank=True)),
+                ('allow_comments', models.BooleanField(default=True, verbose_name='Allow comments')),
+                ('featured_image', mezzanine.core.fields.FileField(max_length=255, null=True, verbose_name='Featured Image', blank=True)),
+            ],
+            options={
+                'ordering': ('-start',),
+                'verbose_name': 'Event',
+                'verbose_name_plural': 'Events',
+            },
+            bases=(models.Model, mezzanine.utils.models.AdminThumbMixin),
+        ),
+        migrations.CreateModel(
+            name='EventLocation',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('title', models.CharField(max_length=500, verbose_name='Title')),
+                ('slug', models.CharField(help_text='Leave blank to have the URL auto-generated from the title.', max_length=2000, null=True, verbose_name='URL', blank=True)),
+                ('address', models.TextField()),
+                ('mappable_location', models.CharField(help_text='This address will be used to calculate latitude and longitude. Leave blank and set Latitude and Longitude to specify the location yourself, or leave all three blank to auto-fill from the Location field.', max_length=128, blank=True)),
+                ('lat', models.DecimalField(decimal_places=7, max_digits=10, blank=True, help_text='Calculated automatically if mappable location is set.', null=True, verbose_name='Latitude')),
+                ('lon', models.DecimalField(decimal_places=7, max_digits=10, blank=True, help_text='Calculated automatically if mappable location is set.', null=True, verbose_name='Longitude')),
+                ('site', models.ForeignKey(editable=False, to='sites.Site')),
+            ],
+            options={
+                'ordering': ('title',),
+                'verbose_name': 'Event Location',
+                'verbose_name_plural': 'Event Locations',
+            },
+        ),
+        migrations.AddField(
+            model_name='event',
+            name='location',
+            field=models.ForeignKey(blank=True, to='mezzanine_agenda.EventLocation', null=True),
+        ),
+        migrations.AddField(
+            model_name='event',
+            name='site',
+            field=models.ForeignKey(editable=False, to='sites.Site'),
+        ),
+        migrations.AddField(
+            model_name='event',
+            name='user',
+            field=models.ForeignKey(related_name='events', verbose_name='Author', to=settings.AUTH_USER_MODEL),
+        ),
+    ]


### PR DESCRIPTION
Add a migration file for the initial `manage.py migrate` process. This file was generated using `manage.py makemigrations mezzanine_agenda`.

Currently, if you add mezzanine-agenda as an application dependence in requirements.txt, an initial `migrate` command fails because Django tries to build tables for the application before other things get applied that it requires on (like `sites`). This fixes that dependency break and allows users to run `migrate` from a clean installation successfully.